### PR TITLE
feat: Add support for Consent State

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,5 +1,12 @@
+var ConsentHandler = require('./consent');
 function Common() {
     this.customDataLayerName = null;
+
+    this.consentMappings = [];
+    this.consentPayloadDefaults = {};
+    this.consentPayloadAsString = '';
+
+    this.consentHandler = new ConsentHandler(this);
 }
 
 Common.prototype.buildMPID = function(event, user) {
@@ -116,6 +123,26 @@ Common.prototype.send = function(_attributes) {
     }
 
     window[this.customDataLayerName].push(payload);
+};
+
+Common.prototype.sendConsent = function (type, payload) {
+    // Google Tag Manager doesn't directly use the gtag function
+    // but recommends pushing directly into the dataLayer
+    // https://developers.google.com/tag-manager/devguide
+    var customDataLayerName = this.customDataLayerName;
+    function customDataLayer() {
+        window[customDataLayerName].push(arguments);
+    }
+
+    customDataLayer('consent', type, payload);
+};
+
+Common.prototype.cloneObject = function (obj) {
+    return JSON.parse(JSON.stringify(obj));
+};
+
+Common.prototype.isEmpty = function isEmpty(value) {
+    return value == null || !(Object.keys(value) || value).length;
 };
 
 module.exports = Common;

--- a/src/consent.js
+++ b/src/consent.js
@@ -1,0 +1,110 @@
+var googleConsentValues = {
+    // Server Integration uses 'Unspecified' as a value when the setting is 'not set'.
+    // However, this is not used by Google's Web SDK. We are referencing it here as a comment
+    // as a record of this distinction and for posterity.
+    // If Google ever adds this for web, the line can just be uncommented to support this.
+    //
+    // Docs:
+    // Web: https://developers.google.com/tag-platform/gtagjs/reference#consent
+    // S2S: https://developers.google.com/google-ads/api/reference/rpc/v15/ConsentStatusEnum.ConsentStatus
+    //
+    // Unspecified: 'unspecified',
+    Denied: 'denied',
+    Granted: 'granted',
+};
+
+// Declares list of valid Google Consent Properties
+var googleConsentProperties = [
+    'ad_storage',
+    'ad_user_data',
+    'ad_personalization',
+    'analytics_storage',
+];
+
+function ConsentHandler(common) {
+    this.common = common || {};
+}
+
+ConsentHandler.prototype.getUserConsentState = function () {
+    var userConsentState = {};
+
+    if (mParticle.Identity && mParticle.Identity.getCurrentUser) {
+        var currentUser = mParticle.Identity.getCurrentUser();
+
+        if (!currentUser) {
+            return {};
+        }
+
+        var consentState =
+            mParticle.Identity.getCurrentUser().getConsentState();
+
+        if (consentState && consentState.getGDPRConsentState) {
+            userConsentState = consentState.getGDPRConsentState();
+        }
+    }
+
+    return userConsentState;
+};
+
+ConsentHandler.prototype.getEventConsentState = function (eventConsentState) {
+    return eventConsentState && eventConsentState.getGDPRConsentState
+        ? eventConsentState.getGDPRConsentState()
+        : {};
+};
+
+ConsentHandler.prototype.getConsentSettings = function () {
+    var consentSettings = {};
+
+    var googleToMpConsentSettingsMapping = {
+        ad_user_data: 'defaultAdUserDataConsentWeb',
+        ad_personalization: 'defaultAdPersonalizationConsentWeb',
+        ad_storage: 'defaultAdStorageConsentWeb',
+        analytics_storage: 'defaultAnalyticsStorageConsentWeb',
+    };
+
+    var settings = this.common.settings;
+
+    Object.keys(googleToMpConsentSettingsMapping).forEach(function (
+        googleConsentKey
+    ) {
+        var mpConsentSettingKey =
+            googleToMpConsentSettingsMapping[googleConsentKey];
+        var googleConsentValuesKey = settings[mpConsentSettingKey];
+
+        if (googleConsentValuesKey && mpConsentSettingKey) {
+            consentSettings[googleConsentKey] =
+                googleConsentValues[googleConsentValuesKey];
+        }
+    });
+
+    return consentSettings;
+};
+
+ConsentHandler.prototype.generateConsentStatePayloadFromMappings = function (
+    consentState,
+    mappings
+) {
+    if (!mappings) return {};
+
+    var payload = this.common.cloneObject(this.common.consentPayloadDefaults);
+
+    for (var i = 0; i <= mappings.length - 1; i++) {
+        var mappingEntry = mappings[i];
+        var mpMappedConsentName = mappingEntry.map;
+        var googleMappedConsentName = mappingEntry.value;
+
+        if (
+            consentState[mpMappedConsentName] &&
+            googleConsentProperties.indexOf(googleMappedConsentName) !== -1
+        ) {
+            payload[googleMappedConsentName] = consentState[mpMappedConsentName]
+                .Consented
+                ? googleConsentValues.Granted
+                : googleConsentValues.Denied;
+        }
+    }
+
+    return payload;
+};
+
+module.exports = ConsentHandler;

--- a/test/tests.js
+++ b/test/tests.js
@@ -1766,7 +1766,7 @@ describe('GoogleTagManager Forwarder', function() {
             done();
         });
 
-        it('should ignore Unspecified Consent Settings if NOT explicitely defined in Consent State', (done) => {
+        it('should ignore Unspecified Consent Settings if NOT explicitly defined in Consent State', (done) => {
             mParticle.forwarder.init(
                 {
                     dataLayerName: 'mparticle_data_layer',


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
- Adds a check to initForwarder and processEvents so that if the consent state changes, we alert Google via their gtag as per their [Consent Mode Documention](https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced#tag-manager_2)

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - Set up Consent Mapping and Privacy Configuration via the mParticle UI
 - Using our [Data Privacy Controls] instructions, toggle some of the mapped consent states via the developer console
 - Verify that mapped events appear in window.dataLayer via browser developer console as updates with updated values

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6154
