### PR TITLE
fix:send default and update consent payloads on kit init

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -164,7 +164,6 @@ Common.prototype.maybeSendConsentUpdateToGoogle = function (consentState) {
             this.sendConsent('update', updatedConsentPayload);
             this.consentPayloadAsString = eventConsentAsString;
         }
-        
     }
 };
 

--- a/src/common.js
+++ b/src/common.js
@@ -137,6 +137,35 @@ Common.prototype.sendConsent = function (type, payload) {
     customDataLayer('consent', type, payload);
 };
 
+Common.prototype.getEventConsentState = function (eventConsentState) {
+    return eventConsentState && eventConsentState.getGDPRConsentState
+        ? eventConsentState.getGDPRConsentState()
+        : {};
+};
+
+Common.prototype.maybeSendConsentUpdateToGoogle = function (consentState) {
+    // If consent payload is empty,
+    // we never sent an initial default consent state
+    // so we shouldn't send an update.
+    if (this.consentPayloadAsString && this.consentMappings) {
+
+        if (!this.isEmpty(consentState)) {
+            var updatedConsentPayload =
+                this.consentHandler.generateConsentStatePayloadFromMappings(
+                    consentState,
+                    this.consentMappings
+                );
+
+            var eventConsentAsString = JSON.stringify(updatedConsentPayload);
+
+            if (eventConsentAsString !== this.consentPayloadAsString) {
+                this.sendConsent('update', updatedConsentPayload);
+                this.consentPayloadAsString = eventConsentAsString;
+            }
+        }
+    }
+};
+
 Common.prototype.cloneObject = function (obj) {
     return JSON.parse(JSON.stringify(obj));
 };

--- a/src/common.js
+++ b/src/common.js
@@ -147,24 +147,34 @@ Common.prototype.maybeSendConsentUpdateToGoogle = function (consentState) {
     // If consent payload is empty,
     // we never sent an initial default consent state
     // so we shouldn't send an update.
-    if (this.consentPayloadAsString && this.consentMappings) {
+    if (
+        this.consentPayloadAsString && 
+        this.consentMappings && 
+        !this.isEmpty(consentState)
+    ) {
+        var updatedConsentPayload =
+            this.consentHandler.generateConsentStatePayloadFromMappings(
+                consentState,
+                this.consentMappings
+            );
 
-        if (!this.isEmpty(consentState)) {
-            var updatedConsentPayload =
-                this.consentHandler.generateConsentStatePayloadFromMappings(
-                    consentState,
-                    this.consentMappings
-                );
+        var eventConsentAsString = JSON.stringify(updatedConsentPayload);
 
-            var eventConsentAsString = JSON.stringify(updatedConsentPayload);
-
-            if (eventConsentAsString !== this.consentPayloadAsString) {
-                this.sendConsent('update', updatedConsentPayload);
-                this.consentPayloadAsString = eventConsentAsString;
-            }
+        if (eventConsentAsString !== this.consentPayloadAsString) {
+            this.sendConsent('update', updatedConsentPayload);
+            this.consentPayloadAsString = eventConsentAsString;
         }
+        
     }
 };
+
+Common.prototype.sendDefaultConsentPayloadToGoogle = function (consentPayload) {
+    this.consentPayloadAsString = JSON.stringify(
+        consentPayload
+    );
+
+    this.sendConsent('default', consentPayload);
+}
 
 Common.prototype.cloneObject = function (obj) {
     return JSON.parse(JSON.stringify(obj));

--- a/src/consent.js
+++ b/src/consent.js
@@ -46,12 +46,6 @@ ConsentHandler.prototype.getUserConsentState = function () {
     return userConsentState;
 };
 
-ConsentHandler.prototype.getEventConsentState = function (eventConsentState) {
-    return eventConsentState && eventConsentState.getGDPRConsentState
-        ? eventConsentState.getGDPRConsentState()
-        : {};
-};
-
 ConsentHandler.prototype.getConsentSettings = function () {
     var consentSettings = {};
 

--- a/src/event-handler.js
+++ b/src/event-handler.js
@@ -2,34 +2,11 @@ function EventHandler(common) {
     this.common = common || {};
 }
 
-EventHandler.prototype.maybeSendConsentUpdateToGoogle = function (event) {
-    // If consent payload is empty,
-    // we never sent an initial default consent state
-    // so we shouldn't send an update.
-    if (this.common.consentPayloadAsString && this.common.consentMappings) {
-        var eventConsentState = this.common.consentHandler.getEventConsentState(
-            event.ConsentState
-        );
-
-        if (!this.common.isEmpty(eventConsentState)) {
-            var updatedConsentPayload =
-                this.common.consentHandler.generateConsentStatePayloadFromMappings(
-                    eventConsentState,
-                    this.common.consentMappings
-                );
-
-            var eventConsentAsString = JSON.stringify(updatedConsentPayload);
-
-            if (eventConsentAsString !== this.common.consentPayloadAsString) {
-                this.common.sendConsent('update', updatedConsentPayload);
-                this.common.consentPayloadAsString = eventConsentAsString;
-            }
-        }
-    }
-};
-
 EventHandler.prototype.logEvent = function (event) {
-    this.maybeSendConsentUpdateToGoogle(event);
+    var eventConsentState = this.common.getEventConsentState(
+        event.ConsentState
+    );
+    this.common.maybeSendConsentUpdateToGoogle(eventConsentState);
     this.common.send({
         event: event,
     });
@@ -40,7 +17,10 @@ EventHandler.prototype.logEvent = function (event) {
 EventHandler.prototype.logError = function() {};
 
 EventHandler.prototype.logPageView = function (event) {
-    this.maybeSendConsentUpdateToGoogle(event);
+    var eventConsentState = this.common.getEventConsentState(
+        event.ConsentState
+    );
+    this.common.maybeSendConsentUpdateToGoogle(eventConsentState);
     this.common.send({
         event: event,
         eventType: 'screen_view'

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -70,26 +70,18 @@ var initialization = {
         common.consentPayloadDefaults =
             common.consentHandler.getConsentSettings();
 
-        var defaultConsentPayload = common.cloneObject(common.consentPayloadDefaults)
-        var updatedConsentState = common.consentHandler.getUserConsentState();
-        var updatedDefaultConsentPayload =
+        var defaultConsentPayload = common.cloneObject(common.consentPayloadDefaults),
+            updatedConsentState = common.consentHandler.getUserConsentState(),
+            updatedDefaultConsentPayload =
         common.consentHandler.generateConsentStatePayloadFromMappings(
             updatedConsentState,
             common.consentMappings
         );
 
         if (!common.isEmpty(defaultConsentPayload)) {
-            common.consentPayloadAsString = JSON.stringify(
-                defaultConsentPayload
-            );
-
-            common.sendConsent('default', defaultConsentPayload);
+            common.sendDefaultConsentPayloadToGoogle(defaultConsentPayload)
         } else if (!common.isEmpty(updatedDefaultConsentPayload)) {
-            common.consentPayloadAsString = JSON.stringify(
-                updatedDefaultConsentPayload
-            );
-
-            common.sendConsent('default', updatedDefaultConsentPayload);
+            common.sendDefaultConsentPayloadToGoogle(updatedDefaultConsentPayload)
         }
 
         common.maybeSendConsentUpdateToGoogle(updatedConsentState)

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -78,13 +78,16 @@ var initialization = {
                 common.consentMappings
             );
 
+        // If a default consent payload exists (as selected in the mParticle UI), set it as the default
         if (!common.isEmpty(defaultConsentPayload)) {
-            common.sendDefaultConsentPayloadToGoogle(defaultConsentPayload)
+            common.sendDefaultConsentPayloadToGoogle(defaultConsentPayload);
+        // If a default consent payload does not exist, but the user currently has updated their consent,
+        // send that as the default because a default must be sent
         } else if (!common.isEmpty(updatedDefaultConsentPayload)) {
-            common.sendDefaultConsentPayloadToGoogle(updatedDefaultConsentPayload)
+            common.sendDefaultConsentPayloadToGoogle(updatedDefaultConsentPayload);
         }
 
-        common.maybeSendConsentUpdateToGoogle(updatedConsentState)
+        common.maybeSendConsentUpdateToGoogle(updatedConsentState);
             
     },
 };

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -70,13 +70,13 @@ var initialization = {
         common.consentPayloadDefaults =
             common.consentHandler.getConsentSettings();
 
-        var defaultConsentPayload = common.cloneObject(common.consentPayloadDefaults),
-            updatedConsentState = common.consentHandler.getUserConsentState(),
-            updatedDefaultConsentPayload =
-        common.consentHandler.generateConsentStatePayloadFromMappings(
-            updatedConsentState,
-            common.consentMappings
-        );
+        var defaultConsentPayload = common.cloneObject(common.consentPayloadDefaults);
+        var updatedConsentState = common.consentHandler.getUserConsentState();
+        var  updatedDefaultConsentPayload =
+            common.consentHandler.generateConsentStatePayloadFromMappings(
+                updatedConsentState,
+                common.consentMappings
+            );
 
         if (!common.isEmpty(defaultConsentPayload)) {
             common.sendDefaultConsentPayloadToGoogle(defaultConsentPayload)

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -72,7 +72,7 @@ var initialization = {
 
         var defaultConsentPayload = common.cloneObject(common.consentPayloadDefaults);
         var updatedConsentState = common.consentHandler.getUserConsentState();
-        var  updatedDefaultConsentPayload =
+        var updatedDefaultConsentPayload =
             common.consentHandler.generateConsentStatePayloadFromMappings(
                 updatedConsentState,
                 common.consentMappings

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -69,13 +69,14 @@ var initialization = {
 
         common.consentPayloadDefaults =
             common.consentHandler.getConsentSettings();
-        var initialConsentState = common.consentHandler.getUserConsentState();
 
-        var defaultConsentPayload =
-            common.consentHandler.generateConsentStatePayloadFromMappings(
-                initialConsentState,
-                common.consentMappings
-            );
+        var defaultConsentPayload = common.cloneObject(common.consentPayloadDefaults)
+        var updatedConsentState = common.consentHandler.getUserConsentState();
+        var updatedDefaultConsentPayload =
+        common.consentHandler.generateConsentStatePayloadFromMappings(
+            updatedConsentState,
+            common.consentMappings
+        );
 
         if (!common.isEmpty(defaultConsentPayload)) {
             common.consentPayloadAsString = JSON.stringify(
@@ -83,7 +84,16 @@ var initialization = {
             );
 
             common.sendConsent('default', defaultConsentPayload);
+        } else if (!common.isEmpty(updatedDefaultConsentPayload)) {
+            common.consentPayloadAsString = JSON.stringify(
+                updatedDefaultConsentPayload
+            );
+
+            common.sendConsent('default', updatedDefaultConsentPayload);
         }
+
+        common.maybeSendConsentUpdateToGoogle(updatedConsentState)
+            
     },
 };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1732,7 +1732,7 @@ describe('GoogleTagManager Forwarder', function() {
             done();
         });
 
-        it('should merge Consent Setting Defaults with User Consent State to construct a Default Consent State', (done) => {
+        it('should construct a Default Consent State Payload from Default Settings and construct an Update Consent State Payload from Mappings', (done) => {
             mParticle.forwarder.init(
                 {
                     dataLayerName: 'mparticle_data_layer',
@@ -1747,9 +1747,22 @@ describe('GoogleTagManager Forwarder', function() {
                 true
             );
 
-            var expectedDataLayer = [
+            // default consent payload from Default Settings sent first
+            var expectedDataLayer1 = [
                 'consent',
                 'default',
+                {
+                    ad_personalization: 'granted', // From Consent Settings
+                    ad_user_data: 'granted', // From Consent Settings
+                    ad_storage: 'granted', // From Consent Settings
+                    analytics_storage: 'granted', // From Consent Settings
+                },
+            ];
+
+            // updated consent payload from mappings sent after
+            var expectedDataLayer2 = [
+                'consent',
+                'update',
                 {
                     ad_personalization: 'denied', // From User Consent State
                     ad_user_data: 'denied', // From User Consent State
@@ -1758,10 +1771,13 @@ describe('GoogleTagManager Forwarder', function() {
                 },
             ];
 
-            mockDataLayer.length.should.eql(1);
+            mockDataLayer.length.should.eql(2);
             mockDataLayer[0][0].should.equal('consent');
             mockDataLayer[0][1].should.equal('default');
-            mockDataLayer[0][2].should.deepEqual(expectedDataLayer[2]);
+            mockDataLayer[0][2].should.deepEqual(expectedDataLayer1[2]);
+            mockDataLayer[1][0].should.equal('consent');
+            mockDataLayer[1][1].should.equal('update');
+            mockDataLayer[1][2].should.deepEqual(expectedDataLayer2[2]);
 
             done();
         });
@@ -1969,7 +1985,20 @@ describe('GoogleTagManager Forwarder', function() {
                 true
             );
 
-            var expectedDataLayerBefore = [
+            // default consent payload from Default Settings sent first
+            var expectedDataLayerBefore1 = [
+                'consent',
+                'update',
+                {
+                    ad_personalization: 'granted', // From Consent Settings
+                    ad_user_data: 'granted', // From Consent Settings
+                    ad_storage: 'granted', // From Consent Settings
+                    analytics_storage: 'granted', // From Consent Settings
+                },
+            ];
+
+            // updated consent payload from mappings sent after
+            var expectedDataLayerBefore2 = [
                 'consent',
                 'update',
                 {
@@ -1980,10 +2009,13 @@ describe('GoogleTagManager Forwarder', function() {
                 },
             ];
 
-            mockDataLayer.length.should.eql(1);
+            mockDataLayer.length.should.eql(2);
             mockDataLayer[0][0].should.equal('consent');
             mockDataLayer[0][1].should.equal('default');
-            mockDataLayer[0][2].should.deepEqual(expectedDataLayerBefore[2]);
+            mockDataLayer[0][2].should.deepEqual(expectedDataLayerBefore1[2]);
+            mockDataLayer[1][0].should.equal('consent');
+            mockDataLayer[1][1].should.equal('update');
+            mockDataLayer[1][2].should.deepEqual(expectedDataLayerBefore2[2]);
 
             mParticle.forwarder.process({
                 EventName: 'Test Event 1',
@@ -2038,12 +2070,12 @@ describe('GoogleTagManager Forwarder', function() {
             // Consent Defaults at index 0
             // Consent Update at index 1
             // Test Event 1 at index 2
-            mockDataLayer.length.should.eql(3);
-            mockDataLayer[1][0].should.equal('consent');
-            mockDataLayer[1][1].should.equal('update');
-            mockDataLayer[1][2].should.deepEqual(expectedDataLayerAfter[2]);
+            mockDataLayer.length.should.eql(4);
+            mockDataLayer[2][0].should.equal('consent');
+            mockDataLayer[2][1].should.equal('update');
+            mockDataLayer[2][2].should.deepEqual(expectedDataLayerAfter[2]);
 
-            mockDataLayer[2].should.have.property('event');
+            mockDataLayer[3].should.have.property('event');
 
             mParticle.forwarder.process({
                 EventName: 'Test Event',
@@ -2109,12 +2141,12 @@ describe('GoogleTagManager Forwarder', function() {
             // Test Event 1 at index 2
             // Consent Update at index 3
             // Test Event 2 at index 4
-            mockDataLayer.length.should.eql(5);
-            mockDataLayer[3][0].should.equal('consent');
-            mockDataLayer[3][1].should.equal('update');
-            mockDataLayer[3][2].should.deepEqual(expectedDataLayerFinal[2]);
+            mockDataLayer.length.should.eql(6);
+            mockDataLayer[4][0].should.equal('consent');
+            mockDataLayer[4][1].should.equal('update');
+            mockDataLayer[4][2].should.deepEqual(expectedDataLayerFinal[2]);
 
-            mockDataLayer[4].should.have.property('event');
+            mockDataLayer[5].should.have.property('event');
 
             done();
         });


### PR DESCRIPTION
 ## Summary
 - Per this google [doc](https://developers.google.com/tag-platform/tag-manager/templates/consent-apis#to_add_the_implementation_code) code block, we should always send the default consent state as is and then listen and send an update consent state payload instead of merging the updated consent state as the new default, this issue was brought to our attention by a customer

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - Unit tested and E2E tested (refer to this doc [here](https://docs.google.com/document/d/1RJYK8TP_OnERCDyJVIA6AIuKJr0LFRzzNW0HWRN7oZA/edit?usp=sharing) with sample screenshot and new workflow)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-6586
