### PR TITLE
feat: Support setting for OneTrust auto-block prevention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.1.2](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-tag-manager/compare/v2.1.1...v2.1.2) (2024-09-19)
+
+
+### Bug Fixes
+
+* Always send default consent payload (if available) before updating ([4c88305](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-tag-manager/commit/4c8830568e00c0e4bdd131c7d8d33893919b152e))
+
 ## [2.1.1](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-tag-manager/compare/v2.1.0...v2.1.1) (2024-04-11)
 
 

--- a/dist/GoogleTagManager-Kit.common.js
+++ b/dist/GoogleTagManager-Kit.common.js
@@ -50,12 +50,6 @@ ConsentHandler.prototype.getUserConsentState = function () {
     return userConsentState;
 };
 
-ConsentHandler.prototype.getEventConsentState = function (eventConsentState) {
-    return eventConsentState && eventConsentState.getGDPRConsentState
-        ? eventConsentState.getGDPRConsentState()
-        : {};
-};
-
 ConsentHandler.prototype.getConsentSettings = function () {
     var consentSettings = {};
 
@@ -249,6 +243,44 @@ Common.prototype.sendConsent = function (type, payload) {
     }
 
     customDataLayer('consent', type, payload);
+};
+
+Common.prototype.getEventConsentState = function (eventConsentState) {
+    return eventConsentState && eventConsentState.getGDPRConsentState
+        ? eventConsentState.getGDPRConsentState()
+        : {};
+};
+
+Common.prototype.maybeSendConsentUpdateToGoogle = function (consentState) {
+    // If consent payload is empty,
+    // we never sent an initial default consent state
+    // so we shouldn't send an update.
+    if (
+        this.consentPayloadAsString && 
+        this.consentMappings && 
+        !this.isEmpty(consentState)
+    ) {
+        var updatedConsentPayload =
+            this.consentHandler.generateConsentStatePayloadFromMappings(
+                consentState,
+                this.consentMappings
+            );
+
+        var eventConsentAsString = JSON.stringify(updatedConsentPayload);
+
+        if (eventConsentAsString !== this.consentPayloadAsString) {
+            this.sendConsent('update', updatedConsentPayload);
+            this.consentPayloadAsString = eventConsentAsString;
+        }
+    }
+};
+
+Common.prototype.sendDefaultConsentPayloadToGoogle = function (consentPayload) {
+    this.consentPayloadAsString = JSON.stringify(
+        consentPayload
+    );
+
+    this.sendConsent('default', consentPayload);
 };
 
 Common.prototype.cloneObject = function (obj) {
@@ -576,34 +608,11 @@ function EventHandler(common) {
     this.common = common || {};
 }
 
-EventHandler.prototype.maybeSendConsentUpdateToGoogle = function (event) {
-    // If consent payload is empty,
-    // we never sent an initial default consent state
-    // so we shouldn't send an update.
-    if (this.common.consentPayloadAsString && this.common.consentMappings) {
-        var eventConsentState = this.common.consentHandler.getEventConsentState(
-            event.ConsentState
-        );
-
-        if (!this.common.isEmpty(eventConsentState)) {
-            var updatedConsentPayload =
-                this.common.consentHandler.generateConsentStatePayloadFromMappings(
-                    eventConsentState,
-                    this.common.consentMappings
-                );
-
-            var eventConsentAsString = JSON.stringify(updatedConsentPayload);
-
-            if (eventConsentAsString !== this.common.consentPayloadAsString) {
-                this.common.sendConsent('update', updatedConsentPayload);
-                this.common.consentPayloadAsString = eventConsentAsString;
-            }
-        }
-    }
-};
-
 EventHandler.prototype.logEvent = function (event) {
-    this.maybeSendConsentUpdateToGoogle(event);
+    var eventConsentState = this.common.getEventConsentState(
+        event.ConsentState
+    );
+    this.common.maybeSendConsentUpdateToGoogle(eventConsentState);
     this.common.send({
         event: event,
     });
@@ -614,7 +623,10 @@ EventHandler.prototype.logEvent = function (event) {
 EventHandler.prototype.logError = function() {};
 
 EventHandler.prototype.logPageView = function (event) {
-    this.maybeSendConsentUpdateToGoogle(event);
+    var eventConsentState = this.common.getEventConsentState(
+        event.ConsentState
+    );
+    this.common.maybeSendConsentUpdateToGoogle(eventConsentState);
     this.common.send({
         event: event,
         eventType: 'screen_view'
@@ -785,21 +797,26 @@ var initialization = {
 
         common.consentPayloadDefaults =
             common.consentHandler.getConsentSettings();
-        var initialConsentState = common.consentHandler.getUserConsentState();
 
-        var defaultConsentPayload =
+        var defaultConsentPayload = common.cloneObject(common.consentPayloadDefaults);
+        var updatedConsentState = common.consentHandler.getUserConsentState();
+        var updatedDefaultConsentPayload =
             common.consentHandler.generateConsentStatePayloadFromMappings(
-                initialConsentState,
+                updatedConsentState,
                 common.consentMappings
             );
 
+        // If a default consent payload exists (as selected in the mParticle UI), set it as the default
         if (!common.isEmpty(defaultConsentPayload)) {
-            common.consentPayloadAsString = JSON.stringify(
-                defaultConsentPayload
-            );
-
-            common.sendConsent('default', defaultConsentPayload);
+            common.sendDefaultConsentPayloadToGoogle(defaultConsentPayload);
+        // If a default consent payload does not exist, but the user currently has updated their consent,
+        // send that as the default because a default must be sent
+        } else if (!common.isEmpty(updatedDefaultConsentPayload)) {
+            common.sendDefaultConsentPayloadToGoogle(updatedDefaultConsentPayload);
         }
+
+        common.maybeSendConsentUpdateToGoogle(updatedConsentState);
+            
     },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/web-google-tag-manager-kit",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/web-google-tag-manager-kit",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
         "@mparticle/web-sdk": "^2.11.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/web-google-tag-manager-kit",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-google-tag-manager",
   "main": "dist/GoogleTagManager-Kit.common.js",
   "browser": "dist/GoogleTagManager-Kit.common.js",

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -63,7 +63,8 @@ var initialization = {
             isInitialized = initializeContainer(
                 containerId,
                 common.customDataLayerName,
-                previewUrl
+                previewUrl,
+                common.settings
             );
         }
 
@@ -88,11 +89,10 @@ var initialization = {
         }
 
         common.maybeSendConsentUpdateToGoogle(updatedConsentState);
-            
     },
 };
 
-function initializeContainer(containerId, dataLayerName, previewUrl) {
+function initializeContainer(containerId, dataLayerName, previewUrl, settings) {
     var url = 'https://www.googletagmanager.com/gtm.js';
 
     // If Settings contains previewUrl, we should tack that onto the gtm snippet
@@ -107,21 +107,27 @@ function initializeContainer(containerId, dataLayerName, previewUrl) {
 
     url += '&l=' + dataLayerName;
 
-    loadSnippet(url, dataLayerName);
+    loadSnippet(url, dataLayerName, settings);
 
     return true;
 }
 
-function loadSnippet(url, dataLayerName) {
+function loadSnippet(url, dataLayerName, settings) {
     window[dataLayerName].push({
         'gtm.start': new Date().getTime(),
-        event: 'gtm.js'
+        event: 'gtm.js',
     });
 
     var gTagScript = document.createElement('script');
     gTagScript.type = 'text/javascript';
     gTagScript.async = true;
     gTagScript.src = url;
+    if (settings.preventAutoBlock === 'True') {
+        gTagScript.setAttributeNode(
+            window.document.createAttribute('data-ot-ignore')
+        );
+    }
+
     (
         document.getElementsByTagName('head')[0] ||
         document.getElementsByTagName('body')[0]

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -64,7 +64,7 @@ var initialization = {
                 containerId,
                 common.customDataLayerName,
                 previewUrl,
-                common.settings
+                common.settings.preventAutoBlock
             );
         }
 
@@ -92,7 +92,12 @@ var initialization = {
     },
 };
 
-function initializeContainer(containerId, dataLayerName, previewUrl, settings) {
+function initializeContainer(
+    containerId,
+    dataLayerName,
+    previewUrl,
+    preventAutoBlock
+) {
     var url = 'https://www.googletagmanager.com/gtm.js';
 
     // If Settings contains previewUrl, we should tack that onto the gtm snippet
@@ -107,12 +112,12 @@ function initializeContainer(containerId, dataLayerName, previewUrl, settings) {
 
     url += '&l=' + dataLayerName;
 
-    loadSnippet(url, dataLayerName, settings);
+    loadSnippet(url, dataLayerName, preventAutoBlock);
 
     return true;
 }
 
-function loadSnippet(url, dataLayerName, settings) {
+function loadSnippet(url, dataLayerName, preventAutoBlock) {
     window[dataLayerName].push({
         'gtm.start': new Date().getTime(),
         event: 'gtm.js',
@@ -122,7 +127,7 @@ function loadSnippet(url, dataLayerName, settings) {
     gTagScript.type = 'text/javascript';
     gTagScript.async = true;
     gTagScript.src = url;
-    if (settings.preventAutoBlock === 'True') {
+    if (preventAutoBlock === 'True') {
         gTagScript.setAttributeNode(
             window.document.createAttribute('data-ot-ignore')
         );


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 Under certain circumstances, OneTrust will autoblock GTM from loading because it is a known tracker.  Per [OneTrust docs](https://my.onetrust.com/s/article/UUID-71e7d0a8-03d8-e272-e683-72cadded2ecf?language=en_US), this can be prevented by adding a `data-ot-ignore` attribute to the script tag.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why. - 
  - We cannot add unit tests because when the kit runs the automated tests, the kit does not load the script for GTM which is where the new code lies, so I manually tested this.  While I cannot get OneTrust to autoblock GTM when loading both (it seems to require some settings on OneTrust's UI), this PR follows the docs by adding the `data-ot-ignore` attribute, and does successfully add the attribute when viewing `Elements` in the inspector.  See the screenshot below

![image](https://github.com/user-attachments/assets/23c162bb-d7fd-4b30-9409-cdc3a07fb137)

 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6520